### PR TITLE
AUI-1028 - Add option to bypass html escaping in textboxlistentry

### DIFF
--- a/src/aui-textboxlist-deprecated/assets/aui-textboxlist-deprecated-core.css
+++ b/src/aui-textboxlist-deprecated/assets/aui-textboxlist-deprecated-core.css
@@ -64,7 +64,3 @@
 .textboxlistentry-remove .icon-remove {
 	margin-top: 0;
 }
-
-.textboxlistentry-remove-hover {
-	background-color: #CAD8F3;
-}

--- a/src/aui-textboxlist-deprecated/js/aui-textboxlist-deprecated.js
+++ b/src/aui-textboxlist-deprecated/js/aui-textboxlist-deprecated.js
@@ -102,6 +102,9 @@ var TextboxList = A.Component.create(
 			delimChar: {
 				value: ''
 			},
+			escapedContent: {
+				value: false
+			},
 			tabIndex: {
 				value: 0
 			}
@@ -430,6 +433,7 @@ var TextboxList = A.Component.create(
 				var eventType = event.type;
 				var inputNode = instance.inputNode;
 				var entryHolder = instance.entryHolder;
+				var escaped = instance.get('escapedContent');
 				var item = event.item;
 				var index = event.index;
 
@@ -441,7 +445,8 @@ var TextboxList = A.Component.create(
 					if (eventType == 'dataset:add') {
 						var entry = new TextboxListEntry(
 							{
-								labelText: key
+								labelText: key,
+								escapedContent: escaped
 							}
 						);
 
@@ -494,6 +499,9 @@ var TextboxListEntry = A.Component.create(
 			},
 			tabIndex: {
 				value: 0
+			},
+			escapedContent: {
+				value: false
 			}
 		},
 
@@ -509,6 +517,10 @@ var TextboxListEntry = A.Component.create(
 				var close = A.Node.create(TPL_ENTRY_REMOVE);
 
 				var labelText = A.Escape.html(instance.get('labelText'));
+
+				if (instance.get('escapedContent')) {
+					labelText = instance.get('labelText');
+				}
 
 				text.set('innerHTML', labelText);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-1028
https://issues.liferay.com/browse/LPS-41658

Hey Jon,

I also removed background-color on textboxlistentry-remove-hover because it was making the remove icon look funny on hover. Here's a screenshot of what the css bug looked like. https://www.evernote.com/shard/s241/sh/0fc3b626-07fe-4798-bace-ba30f7581810/55722e48cc9053603854e046b3347260

Patrick
