### PR TITLE
AUI-1345 - Modal can't be hidden when destroyOnHide is false

### DIFF
--- a/src/aui-modal/assets/aui-modal-core.css
+++ b/src/aui-modal/assets/aui-modal-core.css
@@ -1,4 +1,4 @@
-.modal-hidden {
+.modal-dialog-hidden {
     display: none;
 }
 


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1345.

I think this must have just been an oversight when they upgraded to bootstrap 3.

Please let me know if there are any issues.

Thanks!
