### PR TITLE
AUI-1420 Form builder text fields overflow when width attribute has invalid value

### DIFF
--- a/src/aui-form-builder/js/aui-form-builder-field-text.js
+++ b/src/aui-form-builder/js/aui-form-builder-field-text.js
@@ -73,7 +73,10 @@ var FormBuilderTextField = A.Component.create({
          * @default 'small'
          */
         width: {
-            value: 'small'
+            setter: function(val) {
+                val = L.String.toLowerCase(val);
+                return (val in WIDTH_VALUES_MAP) ? val : 'small';
+            }
         }
 
     },


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/AUI-1420.

The width of the text field is styled by the Bootstrap 3 .col classes defined in WIDTH_VALUES_MAP. Therefore, the width attribute should only have values defined in the WIDTH_VALUES_MAP object. I added a setter function in the width attribute to check this.

Please let me know if there's any issues. Thanks!
