### PR TITLE
AUI-1412 - AUI Color Picker Deprecated uses A.Panel which throws JS error

### DIFF
--- a/src/aui-color-picker-deprecated/assets/aui-color-picker-base-deprecated-core.css
+++ b/src/aui-color-picker-deprecated/assets/aui-color-picker-base-deprecated-core.css
@@ -114,3 +114,7 @@
 	display: inline;
 	position: static;
 }
+
+.yui3-widget-hd {
+	display: none;
+}

--- a/src/aui-color-picker-deprecated/js/aui-color-picker-base-deprecated.js
+++ b/src/aui-color-picker-deprecated/js/aui-color-picker-base-deprecated.js
@@ -556,17 +556,7 @@ var ColorPicker = A.Component.create(
 				if (!instance._pickerContainer) {
 					var container = new A.Panel(
 						{
-							cssClass: CSS_PANEL,
-							icons: [
-								{
-									icon: 'close',
-									id: 'close',
-									handler: {
-										fn: instance.hide,
-										context: instance
-									}
-								}
-							]
+							bodyContent:'',
 						}
 					).render(instance.get('contentBox'));
 
@@ -575,6 +565,12 @@ var ColorPicker = A.Component.create(
 					bodyNode.addClass(CSS_CONTAINER);
 
 					instance._pickerContainer = bodyNode;
+
+					var yuiPanel = instance.get('contentBox').one('.yui3-panel');
+
+					yuiPanel.addClass(CSS_PANEL);
+
+					yuiPanel.setStyle('position', 'static');
 				}
 			},
 
@@ -816,7 +812,7 @@ var ColorPicker = A.Component.create(
 				instance._preventDragEvent = true;
 
 				dd._setStartPosition(dd.get('dragNode').getXY());
-	            dd._alignNode(xy, true);
+				dd._alignNode(xy, true);
 
 				instance._preventDragEvent = false;
 			},

--- a/src/aui-color-picker-deprecated/meta/aui-color-picker-deprecated.json
+++ b/src/aui-color-picker-deprecated/meta/aui-color-picker-deprecated.json
@@ -9,12 +9,12 @@
     "aui-color-picker-base-deprecated": {
     	"requires": [
     		"dd-drag",
+    		"panel",
     		"slider",
     		"aui-button-item-deprecated",
     		"aui-color-util-deprecated",
     		"aui-form-base-deprecated",
-    		"aui-overlay-context-deprecated",
-    		"aui-panel-deprecated"
+    		"aui-overlay-context-deprecated"
     	],
     	"skinnable": true
     },


### PR DESCRIPTION
Hey @jonmak08,

Here is an update for https://issues.liferay.com/browse/AUI-1412

Note that it was necessary to set the "position" within the js. Let me know if that will be an issue. If i put it in the css, the yui module will put an inline default of relative positioning.

Let me know if i need to change anything. Thanks!