### PR TITLE
AUI-1581 - AUI Carousel demo images don't appear in Firefox

### DIFF
--- a/src/aui-image-viewer/HISTORY.md
+++ b/src/aui-image-viewer/HISTORY.md
@@ -4,7 +4,7 @@
 
 ## @VERSION@
 
-No registries yet.
+* [AUI-1581](https://issues.liferay.com/browse/AUI-1581) AUI Carousel demo images don't appear in Firefox
 
 ## [3.0.0pr2](https://github.com/liferay/alloy-ui/releases/tag/3.0.0pr2)
 

--- a/src/aui-image-viewer/js/aui-image-viewer-base.js
+++ b/src/aui-image-viewer/js/aui-image-viewer-base.js
@@ -787,7 +787,7 @@ A.ImageViewerBase = A.Base.create(
                         sources.push(this.getAttribute('src'));
                     }
                     else {
-                        sources.push(this.getStyle('backgroundImage').slice(4, -1));
+                        sources.push(A.Lang.String.removeAll(this.getStyle('backgroundImage').slice(4, -1), '"'));
                     }
                 });
 


### PR DESCRIPTION
HI Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1581.

It turned out that in Firefox, the getStyle('backgroundImage') method was returning the url in quotes, but in chrome it was not.  That is what was causing the 404's.

Please let me know if there are any issues.

Thanks!
