### PR TITLE
AUI-1611 - The scheduler-event-recorder-date on the popover is not updated after the first click when clicking multiple dates in a row.

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1611](https://issues.liferay.com/browse/AUI-1611) The scheduler-event-recorder-date on the popover is not updated after the first click when clicking multiple dates in a row.
 * [AUI-1591](https://issues.liferay.com/browse/AUI-1591) Fix scheduler behavior on touch screen desktop computers
 * [AUI-1527](https://issues.liferay.com/browse/AUI-1527) add base keyboard navigation
 * [AUI-1370](https://issues.liferay.com/browse/AUI-1370) Add ability to set an event's border color, style, and width

--- a/src/aui-scheduler/js/aui-scheduler-view-table-dd.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table-dd.js
@@ -518,6 +518,8 @@ A.mix(A.SchedulerTableViewDD.prototype, {
                 silent: true
             });
 
+            recorder.populateForm();
+
             recorder.showPopover(instance.lasso);
 
             instance._recording = false;


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1611.

Please let me know if there are any issues.

Thanks!
