### PR TITLE
AUI-1378-Backport aui-form-validator error breaks radio button layout

### DIFF
--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -58,6 +58,7 @@ var Lang = A.Lang,
 	VALID_CLASS = 'validClass',
 	VALIDATE_ON_BLUR = 'validateOnBlur',
 	VALIDATE_ON_INPUT = 'validateOnInput',
+	WRAPPER_CONTENT = 'wrapper-content',
 
 	getCN = A.getClassName,
 
@@ -66,7 +67,7 @@ var Lang = A.Lang,
 	CSS_VALID = getCN(FORM_VALIDATOR, VALID),
 	CSS_VALID_CONTAINER = getCN(FORM_VALIDATOR, VALID, CONTAINER),
 
-	CSS_FIELD = getCN(FIELD),
+	CSS_FIELD = getCN(FIELD, WRAPPER_CONTENT),
 	CSS_MESSAGE = getCN(FORM_VALIDATOR, MESSAGE),
 	CSS_STACK_ERROR = getCN(FORM_VALIDATOR, STACK, ERROR),
 


### PR DESCRIPTION
The logic is similar to the fix in [AUI-1585](https://issues.liferay.com/browse/AUI-1585). Just append the error message to the end of the parent of the radio buttons, instead of putting it right after any one of them.
