### PR TITLE
AUI-1667 Category names with special symbols like & and </b> are not dis...

### DIFF
--- a/src/aui-textboxlist-deprecated/js/aui-textboxlist-deprecated.js
+++ b/src/aui-textboxlist-deprecated/js/aui-textboxlist-deprecated.js
@@ -502,7 +502,7 @@ var TextboxListEntry = A.Component.create({
             var text = A.Node.create(TPL_ENTRY_TEXT);
             var close = A.Node.create(TPL_ENTRY_REMOVE);
 
-            var labelText = A.Escape.html(instance.get('labelText'));
+            var labelText = A.Lang.String.unescapeHTML(instance.get('labelText'));
 
             text.set('innerHTML', labelText);
 


### PR DESCRIPTION
AUI 1667 is a part of LPS-50279. 

I am not sure about the version of AUI used in Trunk and 6210. But this bug is reported by a customer who is using 6210.

The bug is both trunk and 6210.
