### PR TITLE
AUI-1672 Scheduler navigation date for week view is not formatted correctly

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1672](https://issues.liferay.com/browse/AUI-1672) Scheduler navigation date for week view is not formatted correctly
 * [AUI-1641](https://issues.liferay.com/browse/AUI-1641) Events in agenda view does not respond to "click" event when scheduler is disabled
 * [AUI-1635](https://issues.liferay.com/browse/AUI-1635) Fix lint problems
 * [AUI-1601](https://issues.liferay.com/browse/AUI-1601) Source format media query max-width for consistency with Bootstrap

--- a/src/aui-scheduler/js/aui-scheduler-view-week.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-week.js
@@ -212,7 +212,7 @@ var SchedulerWeekView = A.Component.create({
 
             var endDateLabel = A.DataType.Date.format(
                 endDate, {
-                    format: (DateMath.isMonthOverlapWeek(date) ? '%B %d' : '%d') + ', %Y',
+                    format: (DateMath.isMonthOverlapWeek(startDate) ? '%B %d' : '%d') + ', %Y',
                     locale: locale
                 }
             );


### PR DESCRIPTION
Hey @jonmak08,

Here is an update for https://issues.liferay.com/browse/AUI-1672.

The date is not formatted correctly because we pass the wrong date to the method isMonthOverlapWeek. If you look at aui-datatype.js, that method takes the week begin date as its argument, which should be the startDate variable.

Let me know if you have any questions. Thanks!
