### PR TITLE
AUI-1013 - Maximum call stack size exceeded when adding a column to datatable

### DIFF
--- a/src/aui-datatable/HISTORY.md
+++ b/src/aui-datatable/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1013](https://issues.liferay.com/browse/AUI-1013) Maximum call stack size exceeded when adding a column to datatable
 * [AUI-1592](https://issues.liferay.com/browse/AUI-1592) Fix modules behavior on touch screen desktop computers
 
 ## [3.0.0pr2](https://github.com/liferay/alloy-ui/releases/tag/3.0.0pr2)

--- a/src/aui-datatable/js/aui-datatable-core.js
+++ b/src/aui-datatable/js/aui-datatable-core.js
@@ -1,2 +1,2 @@
-A.DataTable.NAME = 'table';
+A.DataTable.NAME = 'datatable';
 A.DataTable.CSS_PREFIX = 'table';


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1013.

This was a difficult one to track down. It was caused by changing the 'NAME' property in aui-datatable-core from 'datatable' to 'table', which in turn was causing 'columnChange' events to be prefixed with 'table'.  Then the '_relayCoreAttrChange' handler in datatable-base would fire, causing the columns attribute to be set again, and so on endlessly until the maximum call stack error is thrown.

Please let me know if there are any issues.

Thanks!
