### PR TITLE
AUI-1039 - Hovering over an ToggleButton in a ToolBar causes the icon to disappear

### DIFF
--- a/src/aui-toolbar/HISTORY.md
+++ b/src/aui-toolbar/HISTORY.md
@@ -4,4 +4,5 @@ AUI Toolbar
 @VERSION@
 ------
 
+	* #AUI-1039 - Hovering over an ToggleButton in a ToolBar causes the icon to disappear
 	* #AUI-971 - Set title attribute to button node during the process of creation.

--- a/src/aui-toolbar/js/aui-toolbar.js
+++ b/src/aui-toolbar/js/aui-toolbar.js
@@ -257,7 +257,7 @@ A.Toolbar = A.Component.create({
             seed.setData(ENCLOSING_WIDGET_INITIALIZED, true);
 
             var enclosingWidget = A.Widget.getByNode(seed),
-                isAlreadyButton = A.instanceOf(enclosingWidget, A.Button),
+                isAlreadyButton = A.instanceOf(enclosingWidget, A.Button) || A.instanceOf(enclosingWidget, A.ToggleButton),
                 isAlreadyButtonGroup = A.instanceOf(enclosingWidget, A.ButtonGroup);
 
             if (isAlreadyButton || isAlreadyButtonGroup) {


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1039.

This issue only occurs on 2.0.x because of changes to YUI's button-core that are in 2.5.x and master.

Please let me know if there are any issues.

Thanks!
