### PR TITLE
AUI-1169 DatePicker does not disappear on tabbing to another field.

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker-popover.js
+++ b/src/aui-datepicker/js/aui-datepicker-popover.js
@@ -16,6 +16,7 @@ var Lang = A.Lang,
     CLICK = 'click',
     CLICKOUTSIDE = 'clickoutside',
     ESC = 'esc',
+    TAB = 'tab',
     KEY = 'key',
     POPOVER = 'popover',
     POPOVER_CSS_CLASS = 'popoverCssClass';
@@ -185,6 +186,11 @@ A.mix(DatePickerPopover.prototype, {
                     node: _DOCUMENT,
                     eventName: KEY,
                     keyCode: ESC
+                },
+                {
+                    node: _DOCUMENT,
+                    eventName: KEY,
+                    keyCode: TAB
                 }
             ],
             position: BOTTOM,


### PR DESCRIPTION
Hello Jon.

One of our customer has reported that the datepicker fails to disappear when he hits the tab key to blur the input.

Currently, the date picker simply not interacts with the tab key, e.g. when tab to the datepicker input, the datepicker is not poped up either.

I am not sure if this is bug, but it does annoy end users if they just want to input information without touching a mouse. Also, I checked the datepicker in jQuery, it does interacts with the tab key.

For AUI-1169, it just focused on the issue of datepicker not disappear. I created another ticket AUI-1814. If you agree that datepicker should be poped up when tabbing to its input. it should be solved as well.

The issue is also reproducible in Trunk. Do I need to sent another pr for Trunk as well?

BTW, I am not sure which AUI branch Trunk is using? 2.5.x or master?

Thanks
John.
