### PR TITLE
AUI-1169 DatePicker does not disappear on blur of trigger.

### DIFF
--- a/src/aui-datepicker/HISTORY.md
+++ b/src/aui-datepicker/HISTORY.md
@@ -1,2 +1,7 @@
 aui-datepicker
 ========
+
+@VERSION@
+------
+
+	* #AUI-1169 DatePicker does not disappear on blur of trigger

--- a/src/aui-datepicker/js/aui-datepicker-delegate.js
+++ b/src/aui-datepicker/js/aui-datepicker-delegate.js
@@ -85,7 +85,11 @@ DatePickerDelegate.prototype = {
 
             container.delegate(
                 CLICK,
-                A.bind('_onceUserInteractionRelease', instance), trigger)
+                A.bind('_onceUserInteractionRelease', instance), trigger),
+
+            container.delegate(
+                'key', A.bind('_handleTabKeyEvent', instance), 'tab', trigger)
+
         ];
 
         instance.publish(
@@ -185,6 +189,16 @@ DatePickerDelegate.prototype = {
         return A.Date.format(date, {
             format: mask
         });
+    },
+
+    /**
+    * Handles tab key events
+    *
+    * @method _handleTabKeyEvent
+    * @protected
+    */
+    _handleTabKeyEvent: function() {
+        this.hide();
     },
 
     /**


### PR DESCRIPTION
Hey Jon

I want the fix in AUI-1169 on 2.0.x.

It seems AUI-1169 is not in master yet, but Maíra has closed it.

Please refer to https://github.com/mairatma/alloy-ui/pull/145 and https://issues.liferay.com/browse/LPS-52226.

Thanks
John.