### PR TITLE
AUI-1125 - aui-selector hidden doesn't account for clip and position: absolute

### DIFF
--- a/src/aui-selector/HISTORY.md
+++ b/src/aui-selector/HISTORY.md
@@ -4,7 +4,7 @@
 
 ## @VERSION@
 
-No registries yet.
+* [AUI-1125](https://issues.liferay.com/browse/AUI-1125) aui-selector hidden doesn't account for clip and position: absolute
 
 ## [3.0.0](https://github.com/liferay/alloy-ui/releases/tag/3.0.0)
 

--- a/src/aui-selector/js/aui-selector.js
+++ b/src/aui-selector/js/aui-selector.js
@@ -6,8 +6,10 @@
 
 var SELECTOR = A.Selector,
 
+    CSS_BOOTSTRAP_SR_ONLY = A.getClassName('sr-only'),
     CSS_HIDE = A.getClassName('hide'),
-    REGEX_HIDDEN_CLASSNAMES = new RegExp(CSS_HIDE);
+    REGEX_HIDDEN_CLASSNAMES = new RegExp(CSS_HIDE),
+    REGEX_SR_ONLY_CLASSNAMES = new RegExp(CSS_BOOTSTRAP_SR_ONLY);
 
 SELECTOR._isNodeHidden = function(node) {
     var width = node.offsetWidth;
@@ -28,7 +30,8 @@ SELECTOR._isNodeHidden = function(node) {
     }
 
     hidden = hidden || (nodeStyle.display === 'none' || nodeStyle.visibility === 'hidden') ||
-        REGEX_HIDDEN_CLASSNAMES.test(className);
+        (nodeStyle.position === 'absolute' && (nodeStyle.clip === 'rect(0px 0px 0px 0px)' || nodeStyle.clip === 'rect(0px,0px,0px,0px)')) ||
+        REGEX_HIDDEN_CLASSNAMES.test(className) || REGEX_SR_ONLY_CLASSNAMES.test(className);
 
     return hidden;
 };

--- a/src/aui-selector/tests/unit/index.html
+++ b/src/aui-selector/tests/unit/index.html
@@ -11,6 +11,7 @@
 </head>
 <body class="yui3-skin-sam">
 <div id="logger"></div>
+<div id="nodeToHide">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
 
 <script>
 YUI({

--- a/src/aui-selector/tests/unit/js/tests.js
+++ b/src/aui-selector/tests/unit/js/tests.js
@@ -3,14 +3,37 @@ YUI.add('aui-selector-tests', function(Y) {
     var suite = new Y.Test.Suite('aui-selector');
 
     suite.add(new Y.Test.Case({
-        name: 'Automated Tests',
-        'test is empty': function() {
-            Y.Assert.pass('No Tests Provided For This Module');
+        name: 'Selector',
+
+        'Hidden selector accounts for position:absolute and clip': function() {
+            var node = Y.one('#nodeToHide');
+
+            node.hideAccessible();
+
+            Y.Assert.isTrue(node.test(':hidden'));
+
+            node.showAccessible();
+
+            Y.Assert.isFalse(node.test(':hidden'));
+
+            node.setStyles({
+                position: 'absolute',
+                clip: 'rect(0 0 0 0)'
+            });
+
+            Y.Assert.isTrue(node.test(':hidden'));
+
+            node.setStyles({
+                clip: 'auto',
+                position: 'static'
+            });
+
+            Y.Assert.isFalse(node.test(':hidden'));
         }
     }));
 
     Y.Test.Runner.add(suite);
 
 }, '', {
-    requires: ['test']
+    requires: ['test', 'aui-selector', 'aui-node-accessible']
 });

--- a/src/aui-selector/tests/unit/js/tests.js
+++ b/src/aui-selector/tests/unit/js/tests.js
@@ -5,7 +5,7 @@ YUI.add('aui-selector-tests', function(Y) {
     suite.add(new Y.Test.Case({
         name: 'Selector',
 
-        'Hidden selector accounts for position:absolute and clip': function() {
+        'Hidden selector accounts for position: absolute and clip styles': function() {
             var node = Y.one('#nodeToHide');
 
             node.hideAccessible();
@@ -17,8 +17,8 @@ YUI.add('aui-selector-tests', function(Y) {
             Y.Assert.isFalse(node.test(':hidden'));
 
             node.setStyles({
-                position: 'absolute',
-                clip: 'rect(0 0 0 0)'
+                clip: 'rect(0 0 0 0)',
+                position: 'absolute'
             });
 
             Y.Assert.isTrue(node.test(':hidden'));


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/AUI-1125.

I made some changes to fix the unit test failing in IE8.

Please let me know if there are any issues.

Thanks!