### PR TITLE
AUI-1835 Scheduler views select dropdown is not set to active view on render

### DIFF
--- a/demos/scheduler/index.html
+++ b/demos/scheduler/index.html
@@ -57,15 +57,18 @@
             }
         ];
 
+        var schedulerViews = [
+            new Y.SchedulerWeekView(),
+            new Y.SchedulerDayView(),
+            new Y.SchedulerMonthView(),
+            new Y.SchedulerAgendaView()
+        ];
+
         new Y.Scheduler({
             boundingBox: '#scheduler',
             items: items,
-            views: [
-                new Y.SchedulerWeekView(),
-                new Y.SchedulerDayView(),
-                new Y.SchedulerMonthView(),
-                new Y.SchedulerAgendaView()
-            ],
+            views: schedulerViews,
+            activeView: schedulerViews[2],
             eventRecorder: new Y.SchedulerEventRecorder()
             // firstDayOfWeek: 1,
             // activeView: weekView,

--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1835](https://issues.liferay.com/browse/AUI-1835) Scheduler views select dropdown is not set to active view on render
 * [AUI-1673](https://issues.liferay.com/browse/AUI-1673) Scheduler button for table-view is lowercase and inconsistent with the other view buttons
 * [AUI-1653](https://issues.liferay.com/browse/AUI-1653) Clean up wrong A.Lang.isNode calls
 * [AUI-1809](https://issues.liferay.com/browse/AUI-1809) Events with duration longer than a week don't render correctly on month view

--- a/src/aui-scheduler/js/aui-scheduler-base.js
+++ b/src/aui-scheduler/js/aui-scheduler-base.js
@@ -1413,6 +1413,7 @@ var SchedulerBase = A.Component.create({
 
                 if (activeNav) {
                     instance.viewsNode.all('button').removeClass(CSS_SCHEDULER_VIEW_SELECTED).setAttribute('aria-pressed', false);
+                    instance.viewsSelectNode.one('[data-view-name=' + activeView + ']').set('selected', true);
                     activeNav.addClass(CSS_SCHEDULER_VIEW_SELECTED).setAttribute('aria-pressed', true);
                 }
             }

--- a/src/aui-scheduler/tests/unit/js/tests.js
+++ b/src/aui-scheduler/tests/unit/js/tests.js
@@ -109,6 +109,21 @@ YUI.add('aui-scheduler-tests', function(Y) {
                 recorder.popover.get('visible'),
                 'Popover should be visible when event is clicked in agenda view'
             );
+        },
+
+        'views select dropdown should be set to active view': function() {
+            this._createScheduler({
+                activeView: this._monthView
+            });
+
+            var options = this._scheduler.viewsSelectNode.get('childNodes');
+            var selectedIndex = this._scheduler.viewsSelectNode.get('selectedIndex');
+
+            Y.Assert.areSame(
+                this._scheduler.get('activeView').get('name'),
+                options.item(selectedIndex).getAttribute('data-view-name'),
+                'The views select dropdown should be set to month view'
+            );
         }
     }));
 


### PR DESCRIPTION
Hey Jon,

Here is an update for https://issues.liferay.com/browse/AUI-1835.

For some reason, [`this._scheduler.viewsSelectNode.get('selectedOptions').first()`](https://github.com/pei-jung/alloy-ui/commit/adfe65236613b8fd0b492787699b9adeb2cf3077#diff-c7555c192b686e44e2975bedde0ac6c2R121) does not work in gulp test, so it throws an undefined object error. I changed it to use the selectedIndex to look for the selected option instead. Please let me know if there's any issues. Thanks!