### PR TITLE
AUI-1900

### DIFF
--- a/src/aui-toggler/HISTORY.md
+++ b/src/aui-toggler/HISTORY.md
@@ -8,6 +8,7 @@ No registries yet.
 
 ## [3.0.1](https://github.com/liferay/alloy-ui/releases/tag/3.0.1)
 
+* [AUI-1900](https://issues.liferay.com/browse/AUI-1900) Toggler should wrap content when expanded attr is set to true
 * [AUI-1627](https://issues.liferay.com/browse/AUI-1627) Remove DOM content added by toggler on destroyed
 * [AUI-1624](https://issues.liferay.com/browse/AUI-1624) Add unit test for toggler module
 * [AUI-1364](https://issues.liferay.com/browse/AUI-1364) Make aui-toggler accessible

--- a/src/aui-toggler/js/aui-toggler-base.js
+++ b/src/aui-toggler/js/aui-toggler-base.js
@@ -204,12 +204,17 @@ var Toggler = A.Component.create({
          * @protected
          */
         initializer: function() {
-            var instance = this;
+            var instance = this,
+            expanded = instance.get('expanded');
 
             instance.bindUI();
             instance.syncUI();
 
-            instance._uiSetExpanded(instance.get('expanded'));
+            instance._uiSetExpanded(expanded);
+
+            if (expanded && !instance.wrapped) {
+                instance._uiSetExpandedContent();
+            }
         },
 
         /**
@@ -444,10 +449,6 @@ var Toggler = A.Component.create({
         _uiSetExpanded: function(val) {
             var instance = this,
                 content = instance.get('content');
-
-            if (val && !instance.wrapped) {
-                instance._uiSetExpandedContent();
-            }
 
             instance.get('content').replaceClass(CSS_TOGGLER_CONTENT_STATE[!val], CSS_TOGGLER_CONTENT_STATE[val]);
             instance.get('header').replaceClass(CSS_TOGGLER_HEADER_STATE[!val], CSS_TOGGLER_HEADER_STATE[val]);

--- a/src/aui-toggler/js/aui-toggler-base.js
+++ b/src/aui-toggler/js/aui-toggler-base.js
@@ -444,7 +444,14 @@ var Toggler = A.Component.create({
          * @protected
          */
         _uiSetExpanded: function(val) {
-            var instance = this;
+            var instance = this,
+                content = instance.get('content');
+
+            if (val && !instance.wrapped) {
+                content.wrap(TPL_CONTENT_WRAPPER);
+
+                instance.wrapped = true;
+            }
 
             instance.get('content').replaceClass(CSS_TOGGLER_CONTENT_STATE[!val], CSS_TOGGLER_CONTENT_STATE[val]);
             instance.get('header').replaceClass(CSS_TOGGLER_HEADER_STATE[!val], CSS_TOGGLER_HEADER_STATE[val]);

--- a/src/aui-toggler/js/aui-toggler-base.js
+++ b/src/aui-toggler/js/aui-toggler-base.js
@@ -401,13 +401,11 @@ var Toggler = A.Component.create({
             }
 
             if (!instance.wrapped) {
-                content.wrap(TPL_CONTENT_WRAPPER);
+                instance._uiSetExpandedContent();
 
                 if (expand) {
                     content.setStyle('marginTop', -(height + gutter));
                 }
-
-                instance.wrapped = true;
             }
 
             instance.set('animating', true);
@@ -448,13 +446,25 @@ var Toggler = A.Component.create({
                 content = instance.get('content');
 
             if (val && !instance.wrapped) {
-                content.wrap(TPL_CONTENT_WRAPPER);
-
-                instance.wrapped = true;
+                instance._uiSetExpandedContent();
             }
 
             instance.get('content').replaceClass(CSS_TOGGLER_CONTENT_STATE[!val], CSS_TOGGLER_CONTENT_STATE[val]);
             instance.get('header').replaceClass(CSS_TOGGLER_HEADER_STATE[!val], CSS_TOGGLER_HEADER_STATE[val]);
+        },
+
+        /**
+         * Wrap the content HTML if `expanded` attribute is true.
+         *
+         * @method _uiSetExpandedContent
+         * @protected
+         */
+        _uiSetExpandedContent: function() {
+            var instance = this;
+
+            instance.get('content').wrap(TPL_CONTENT_WRAPPER);
+
+            instance.wrapped = true;
         }
 
     }

--- a/src/aui-toggler/tests/unit/js/tests.js
+++ b/src/aui-toggler/tests/unit/js/tests.js
@@ -88,15 +88,12 @@ YUI.add('aui-toggler-base-tests', function(Y) {
         },
 
         'should wrap content when expanded is set to true': function() {
-            this.createToggler({
-                content: '.content',
-                expanded: true,
-                header: '.accordion-heading'
-            });
-
             var toggler = this._toggler;
 
-            Y.Assert.isTrue(toggler.wrapped)
+            toggler.set('expanded' , true);
+
+            Y.Assert.isTrue(toggler.wrapped);
+            Y.Assert.isTrue(this.togglerHasClass('toggler-content-expanded'));
         }
     }));
 

--- a/src/aui-toggler/tests/unit/js/tests.js
+++ b/src/aui-toggler/tests/unit/js/tests.js
@@ -88,9 +88,13 @@ YUI.add('aui-toggler-base-tests', function(Y) {
         },
 
         'should wrap content when expanded is set to true': function() {
-            var toggler = this._toggler;
+            this.createToggler({
+                content: '.content',
+                expanded: true,
+                header: '.accordion-heading'
+            });
 
-            toggler.set('expanded' , true);
+            var toggler = this._toggler;
 
             Y.Assert.isTrue(toggler.wrapped);
             Y.Assert.isTrue(this.togglerHasClass('toggler-content-expanded'));

--- a/src/aui-toggler/tests/unit/js/tests.js
+++ b/src/aui-toggler/tests/unit/js/tests.js
@@ -85,6 +85,18 @@ YUI.add('aui-toggler-base-tests', function(Y) {
 
             toggler.animate({ duration: 0 });
             Y.Assert.isTrue(this.togglerHasClass('toggler-content-expanded'));
+        },
+
+        'should wrap content when expanded is set to true': function() {
+            this.createToggler({
+                content: '.content',
+                expanded: true,
+                header: '.accordion-heading'
+            });
+
+            var toggler = this._toggler;
+
+            Y.Assert.isTrue(toggler.wrapped)
         }
     }));
 


### PR DESCRIPTION
Hey @jonmak08 

Here is an update for [AUI-1900](https://issues.liferay.com/browse/AUI-1900).
I found that `instance._uiSetExpanded(true)` is called inside `getContentHeight`. This causes the content to get wrapped even if `expanded` is false because `true` is being passed in. I moved `instance.uiSetExpandedContent()` into the init function to fix this. Also, when I made that change it revealed that using `toggler.set('expanded', true)` will not work because the toggler instance needs to be initialized with `expanded` set to true. Prior to these changes no errors were thrown from aui-toggler-base tests because the content was always wrapped with the previously mentioned `instance.uiSetExpanded(true)`. However, after I fixed that issue it caused an error in  the aui-toggler-base tests that can be fixed by initializing a new toggler with `expanded: true`. Let me know if this is all okay with you.