### PR TITLE
AUI-1873 aui button visible does not output proper css class

### DIFF
--- a/src/aui-button/assets/aui-button-core-core.css
+++ b/src/aui-button/assets/aui-button-core-core.css
@@ -1,4 +1,8 @@
-.btn-hidden {
+.aui-button-hidden, .yui3-aui-button-hidden {
+    display: none;
+}
+
+.togglebtn-hidden, .yui3-togglebtn-hidden {
     display: none;
 }
 

--- a/src/aui-button/assets/aui-button-switch-core.css
+++ b/src/aui-button/assets/aui-button-switch-core.css
@@ -46,3 +46,7 @@
     right: 2px;
     left: initial;
 }
+
+.button-switch-hidden, .yui3-button-switch-hidden {
+    display: none;
+}

--- a/src/aui-button/js/aui-button-core.js
+++ b/src/aui-button/js/aui-button-core.js
@@ -159,7 +159,7 @@ ButtonExt.prototype = {
 
     /**
      * Includes default button classes if necessary.
-     * Fires after `renderUI` method. 
+     * Fires after `renderUI` method.
      *
      * @method renderButtonExtUI
      * @protected


### PR DESCRIPTION
This is an update for [AUI-1873](https://issues.liferay.com/browse/AUI-1873).

Hey @jonmak08, this is obviously a really simplistic fix, and I did see the pull from a while back: https://github.com/mairatma/alloy-ui/pull/197.  Would you rather apply those changes instead?  If not I figured this might be okay since we're moving away from YUI eventually.  Let me know.  Thanks!

/cc @Robert-Frampton