### PR TITLE
LPS-64993 AUI tooltip misaligned when hovering over subsequent help icons

### DIFF
--- a/src/aui-tooltip/js/aui-tooltip-base.js
+++ b/src/aui-tooltip/js/aui-tooltip-base.js
@@ -136,6 +136,7 @@ A.Tooltip = A.Base.create('tooltip', A.Widget, [
      * @protected
      */
     _afterUiSetTrigger: function(val) {
+        this._loadTooltipContentFromTitle();
         this.suggestAlignment(val);
     },
 

--- a/src/aui-tooltip/js/aui-tooltip-delegate.js
+++ b/src/aui-tooltip/js/aui-tooltip-delegate.js
@@ -118,7 +118,7 @@ A.TooltipDelegate = A.Base.create('tooltip-delegate', A.Base, [], {
 
         trigger = event.currentTarget;
 
-        instance.getTooltip().set('trigger', trigger).render().show();
+        instance.getTooltip().show().set('trigger', trigger).render();
     },
 
     /**


### PR DESCRIPTION
Switch tooltip show to run before setting the trigger.  This prevents the tooltip  from adding it's own value for the offset width & height which causes it to be vertically misaligned.  Add loadTooltipContentFromTitle to _afterUiSetTrigger to prevent tooltip from displaying incorrect text.