### PR TITLE
[Technical Support] AUI-2811 IE8 showing error "Object doesn't support this property or m…

### DIFF
--- a/src/aui-form-validator/HISTORY.md
+++ b/src/aui-form-validator/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-2811](https://issues.liferay.com/browse/AUI-2811) IE8 showing error "Object doesn't support this property or method" for aui-form-validator.js file
 * [AUI-2094](https://issues.liferay.com/browse/AUI-2094) Remove feedback added by Form Validator when the field is not required and empty
 * [AUI-2055](https://issues.liferay.com/browse/AUI-2055) aria-invalid attribute not removed from blank input fields
 * [AUI-2038](https://issues.liferay.com/browse/AUI-2038) UI should alert about non-unique value in structure field of type Select.

--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -875,7 +875,7 @@ var FormValidator = A.Component.create({
             var instance = this;
 
             if (!instance.get('showAllMessages')) {
-                if (errors.indexOf('required') !== -1) {
+                if (A.Array.indexOf(errors, 'required') !== -1) {
                     errors = ['required'];
                 }
                 else {


### PR DESCRIPTION
…ethod" for aui-form-validator.js file

Hi Jon,

I'm sending you a basic fix for ie8 issue in FormValidator.js.
Please keep in mind that we need to backport it to alloy 2.0.x and commit to portal ee-6.2.x.

Thanks in advance,
 Zsaga 