### PR TITLE
AUI-3084 Reset the height monitor so that the text entered in the text area does not persist across pages

### DIFF
--- a/src/aui-autosize-deprecated/js/aui-autosize-deprecated.js
+++ b/src/aui-autosize-deprecated/js/aui-autosize-deprecated.js
@@ -200,6 +200,8 @@ Autosize = A.Component.create({
 
                 instance._uiSetDim(HEIGHT, height);
             }
+
+            heightMonitor.set(INNERHTML, '');
         },
 
         _uiSetDim: function(key, newVal) {


### PR DESCRIPTION
Hey Jon,

I haven't submitted an AUI fix for a while so let me know if I missed something or if this is the incorrect branch.

The issue is that text inputted in the System Settings on DXP is placed into a "pre" element in order to calculate the height the text area should be. This causes a problem because these "pre" elements are not cleared out and appear on other pages. If you think there's a better way to resolve this issue, please feel free to let me know.

Thanks!