### PR TITLE
AUI-1851 - Modifiers and accessors for activeInput now set activeInput to or return null if activeInput is null

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker-delegate.js
+++ b/src/aui-datepicker/js/aui-datepicker-delegate.js
@@ -115,13 +115,9 @@ DatePickerDelegate.prototype = {
     getSelectedDates: function(node) {
         var instance = this,
             activeInput = node || instance.get('activeInput'),
-            selectedDates = activeInput.getData('datepickerSelection');
+            selectedDates = (activeInput ? activeInput.getData('datepickerSelection') : null);
 
-        if (selectedDates) {
-            return selectedDates;
-        }
-
-        return null;
+        return selectedDates;
     },
 
     /**
@@ -202,7 +198,9 @@ DatePickerDelegate.prototype = {
 
         valueFormatter.call(instance, selection);
 
-        activeInput.setData('datepickerSelection', selection);
+        if (activeInput) {
+            activeInput.setData('datepickerSelection', selection);
+        }
     },
 
     /**
@@ -304,7 +302,7 @@ DatePickerDelegate.prototype = {
         return function(opt_value) {
             var instance = this,
                 activeInput = instance.get('activeInput'),
-                activeInputValue = Lang.trim(opt_value || activeInput.val()),
+                activeInputValue = Lang.trim(opt_value || (activeInput ? activeInput.val() : null) ),
                 dateSeparator = instance.get('dateSeparator'),
                 mask = instance.get('mask'),
                 dates;
@@ -343,7 +341,9 @@ DatePickerDelegate.prototype = {
                 values.push(instance._formatDate(date));
             });
 
-            activeInput.val(values.join(dateSeparator));
+            if (activeInput) {
+                activeInput.val(values.join(dateSeparator));
+            }
         };
     }
 };

--- a/src/aui-datepicker/js/aui-datepicker-native.js
+++ b/src/aui-datepicker/js/aui-datepicker-native.js
@@ -98,7 +98,9 @@ DatePickerNativeBase.prototype = {
         var instance = this,
             activeInput = instance.get('activeInput');
 
-        activeInput.val('');
+        if (activeInput) {
+            activeInput.val('');
+        }
     },
 
     /**
@@ -121,7 +123,9 @@ DatePickerNativeBase.prototype = {
         var instance = this,
             activeInput = instance.get('activeInput');
 
-        activeInput.blur();
+        if (activeInput) {
+            activeInput.blur();
+        }
     },
 
     /**
@@ -133,7 +137,9 @@ DatePickerNativeBase.prototype = {
         var instance = this,
             activeInput = instance.get('activeInput');
 
-        activeInput.focus();
+        if (activeInput) {
+          activeInput.focus();
+        }
     },
 
     /**
@@ -150,7 +156,7 @@ DatePickerNativeBase.prototype = {
             dates = dates[0];
         }
 
-        if (Lang.isDate(dates)) {
+        if (Lang.isDate(dates) && activeInput) {
             activeInput.val(instance._formatDate(dates));
         }
     },
@@ -220,7 +226,7 @@ DatePickerNativeBase.prototype = {
     _fireSelectionChange: function() {
         var instance = this,
             activeInput = instance.get('activeInput'),
-            parsed = instance._parseDateFromString(activeInput.val());
+            parsed = (activeInput ? instance._parseDateFromString(activeInput.val()) : null);
 
         instance.fire(
             'selectionChange', {

--- a/src/aui-datepicker/js/aui-datepicker.js
+++ b/src/aui-datepicker/js/aui-datepicker.js
@@ -314,7 +314,7 @@ A.mix(DatePickerBase.prototype, {
     _setCalendarToFirstSelectedDate: function() {
         var instance = this,
             dates = instance.getSelectedDates(),
-            firstSelectedDate = dates[0];
+            firstSelectedDate = (dates ? dates[0] : null);
 
         if (firstSelectedDate) {
             instance.getCalendar().set('date', firstSelectedDate);


### PR DESCRIPTION
Changes made for master.

Would I need to also do the same with the master-deprecated versions?