### PR TITLE
AUI-3104: Make aui-button-switch accessible

### DIFF
--- a/src/aui-aria/js/aui-aria-roles.js
+++ b/src/aui-aria/js/aui-aria-roles.js
@@ -67,6 +67,7 @@ A.Plugin.Aria.W3C_ROLES = {
     'spinbutton': 1,
     'status': 1,
     'structure': 1,
+    'switch': 1,
     'tab': 1,
     'tablist': 1,
     'tabpanel': 1,

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -141,7 +141,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
     },
 
     /**
-     * Fires when space or enter key is pressed.
+     * Fires when space, enter, right, or left key is pressed.
      *
      * @method _onButtonSwitchKey
      * @protected

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -41,6 +41,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
 
         content.on('click', this._onButtonSwitchClick, this);
         content.on('key', this._onButtonSwitchKey, 'enter,space,37,39', this);
+
         this.after('activatedChange', this._afterActivatedChange, this);
         this.after('innerLabelLeftChange', this._afterInnerLabelLeftChange, this);
         this.after('innerLabelRightChange', this._afterInnerLabelRightChange, this);
@@ -61,6 +62,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
             contentBox = this.get('contentBox');
 
         contentBox.append(content);
+
         this._uiSetActivate(this.get('activated'));
         this._uiSetInnerLabelLeft(this.get('innerLabelLeft'));
         this._uiSetInnerLabelRight(this.get('innerLabelRight'));
@@ -80,6 +82,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * Fires after `innerLabelLeft` attribute changes.
      *
      * @method _afterInnerLabelLeftChange
+     * @param event
      * @protected
      */
     _afterInnerLabelLeftChange: function(event) {
@@ -90,6 +93,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * Fires after `innerLabelRight` attribute changes.
      *
      * @method _afterInnerLabelRightChange
+     * @param event
      * @protected
      */
     _afterInnerLabelRightChange: function(event) {
@@ -103,7 +107,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * @return {Node}
      * @protected
      */
-    _getInnerCircle: function () {
+    _getInnerCircle: function() {
         if (!this._innerCircle) {
             this._innerCircle = A.Node.create(TPL_INNER_CIRCLE);
             this.get('content').append(this._innerCircle);
@@ -144,10 +148,11 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * Fires when space, enter, right, or left key is pressed.
      *
      * @method _onButtonSwitchKey
+     * @param event
      * @protected
      */
-    _onButtonSwitchKey: function() {
-        var activated = this.get('activated');
+    _onButtonSwitchKey: function(event) {
+        var activated = this.get('activated'),
             keyCode = event.keyCode;
 
         if ((keyCode == 32 || keyCode == 13) || (keyCode == 39 && !activated) || (keyCode == 37 && activated)) {
@@ -172,22 +177,47 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
                 roleName: role,
                 roleNode: content
             }
-        )
+        );
 
         this.aria.setAttribute('checked', activated, content);
     },
 
     /**
-     * Updates the ui according to the value of the `activated` attribute.
+     * Updates Inner Circle position with CSS classes.
      *
-     * @method _uiSetActivate
+     * @method _setInnerCirclePosition
+     * @param {Boolean} activated
      * @protected
      */
+    _setInnerCirclePosition: function(activated) {
+        var innerCircle = this._getInnerCircle();
+
+        // Clear the styling, as it has higher precedence than css classes.
+        innerCircle.setStyle('left', '');
+
+        if (activated) {
+            innerCircle.removeClass(CSS_BUTTON_SWITCH_LEFT);
+            innerCircle.addClass(CSS_BUTTON_SWITCH_RIGHT);
+        }
+        else {
+            innerCircle.removeClass(CSS_BUTTON_SWITCH_RIGHT);
+            innerCircle.addClass(CSS_BUTTON_SWITCH_LEFT);
+        }
+    },
+
+    /**
+    * Updates the ui according to the value of the `activated` attribute.
+    *
+    * @method _uiSetActivate
+    * @protected
+    */
     _uiSetActivate: function(activated) {
-        var content = this.get('content'),
-            buttonSwitchWidth = content.get('offsetWidth'),
+        var buttonSwitchWidth,
+            content = this.get('content'),
             innerCircle = this._getInnerCircle(),
             innerCircleWidth = innerCircle.get('offsetWidth');
+
+        buttonSwitchWidth = content.get('offsetWidth');
 
         content.one('.' + CSS_INNER_LABEL_RIGHT).toggleClass('hide', activated);
         content.one('.' + CSS_INNER_LABEL_LEFT).toggleClass('hide', !activated);
@@ -214,29 +244,6 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
                     left: INNER_CIRCLE_THRESHOLD + 'px'
                 });
             }
-        }
-    },
-
-    /**
-     * Updates Inner Circle position with CSS classes.
-     *
-     * @method _setInnerCirclePosition
-     * @param {Boolean} activated
-     * @protected
-     */
-    _setInnerCirclePosition: function(activated) {
-        var innerCircle = this._getInnerCircle();
-
-        // Clear the styling, as it has higher precedence than css classes.
-        innerCircle.setStyle('left', '');
-
-        if (activated) {
-            innerCircle.removeClass(CSS_BUTTON_SWITCH_LEFT);
-            innerCircle.addClass(CSS_BUTTON_SWITCH_RIGHT);
-        }
-        else {
-            innerCircle.removeClass(CSS_BUTTON_SWITCH_RIGHT);
-            innerCircle.addClass(CSS_BUTTON_SWITCH_LEFT);
         }
     },
 
@@ -306,8 +313,8 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
          * @type String
          */
         innerLabelLeft: {
-            value: '',
-            validator: A.Lang.isString
+            validator: A.Lang.isString,
+            value: ''
         },
 
         /**
@@ -317,8 +324,8 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
          * @type String
          */
         innerLabelRight: {
-            value: '',
-            validator: A.Lang.isString
+            validator: A.Lang.isString,
+            value: ''
         },
 
         /**
@@ -328,8 +335,8 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
          * @type String
          */
         role: {
-            value: 'switch',
-            validator: A.Lang.isString
+            validator: A.Lang.isString,
+            value: 'switch'
         },
 
         /**

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -37,13 +37,11 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      */
     bindUI: function() {
         var content = this.get('content');
-        A.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowleft = 37;
-        A.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowright = 39;
 
         content.on('click', this._onButtonSwitchClick, this);
         content.on('key', this._onButtonSwitchKey, 'enter,space', this);
-        content.on('key', this._onButtonSwitchRightKey, 'arrowright', this);
-        content.on('key', this._onButtonSwitchLeftKey, 'arrowleft', this);
+        content.on('key', this._onButtonSwitchRightKey, 'down: 39', this);
+        content.on('key', this._onButtonSwitchLeftKey, 'down: 37', this);
         this.after('activatedChange', this._afterActivatedChange, this);
         this.after('innerLabelLeftChange', this._afterInnerLabelLeftChange, this);
         this.after('innerLabelRightChange', this._afterInnerLabelRightChange, this);

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -57,10 +57,15 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
 
         buttonSwitch.append(content);
         buttonSwitch.setAttribute('role', 'switch');
-
         this._uiSetActivate(this.get('activated'));
         this._uiSetInnerLabelLeft(this.get('innerLabelLeft'));
         this._uiSetInnerLabelRight(this.get('innerLabelRight'));
+
+        if (this.get('activated')) {
+            buttonSwitch.setAttribute('aria-checked', 'true');
+        } else {
+            buttonSwitch.setAttribute('aria-checked', 'false');
+        }
     },
 
     /**
@@ -127,6 +132,12 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      */
     _onButtonSwitchInteraction: function() {
         this.set('activated', !this.get('activated'));
+
+        if (this.get('activated')) {
+            this.get('contentBox').setAttribute('aria-checked', 'true');
+        } else {
+            this.get('contentBox').setAttribute('aria-checked', 'false');
+        }
     },
 
     /**

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -45,6 +45,7 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
         this.after('activatedChange', this._afterActivatedChange, this);
         this.after('innerLabelLeftChange', this._afterInnerLabelLeftChange, this);
         this.after('innerLabelRightChange', this._afterInnerLabelRightChange, this);
+        this._syncAriaMenuUI();
     },
 
     /**
@@ -58,16 +59,31 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
         var content = this.get('content');
 
         buttonSwitch.append(content);
-        content.setAttribute('role', 'switch');
         this._uiSetActivate(this.get('activated'));
         this._uiSetInnerLabelLeft(this.get('innerLabelLeft'));
         this._uiSetInnerLabelRight(this.get('innerLabelRight'));
+    },
+
+    /**
+     * Update the aria attributes for the button switch UI.
+     *
+     * @method _syncAriaMenuUI
+     * @protected
+     */
+    _syncAriaMenuUI: function() {
+        var content = this.get('content');
+
+        if (this.get('useARIA')) {
+            this.plug(A.Plugin.Aria);
+        }
 
         if (this.get('activated')) {
-            content.setAttribute('aria-checked', true);
+            this.aria.setAttribute('checked', true, content);
         } else {
-            content.setAttribute('aria-checked', false);
+            this.aria.setAttribute('checked', false, content)
         }
+
+        content.setAttribute('role', 'switch');
     },
 
     /**
@@ -133,12 +149,14 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * @protected
      */
     _onButtonSwitchInteraction: function() {
+        var content = this.get('content');
+
         this.set('activated', !this.get('activated'));
 
         if (this.get('activated')) {
-            this.get('content').setAttribute('aria-checked', true);
+            this.aria.setAttribute('checked', true, content);
         } else {
-            this.get('content').setAttribute('aria-checked', false);
+            this.aria.setAttribute('checked', false, content);
         }
     },
 
@@ -318,6 +336,19 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
         innerLabelRight: {
             value: '',
             validator: A.Lang.isString
+        },
+
+        /**
+        * Boolean indicating if use of the WAI-ARIA Roles and States should be enabled..
+        *
+        * @attribute useARIA
+        * @default true
+        * @type {Boolean}
+        */
+        useARIA: {
+            validator: A.Lang.isBoolean,
+            value: true,
+            writeOnce: 'initOnly'
         }
     }
 });

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -37,9 +37,13 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      */
     bindUI: function() {
         var content = this.get('content');
+        A.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowleft = 37;
+        A.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowright = 39;
 
         content.on('click', this._onButtonSwitchClick, this);
         content.on('key', this._onButtonSwitchKey, 'enter,space', this);
+        content.on('key', this._onButtonSwitchRightKey, 'arrowright', this);
+        content.on('key', this._onButtonSwitchLeftKey, 'arrowleft', this);
         this.after('activatedChange', this._afterActivatedChange, this);
         this.after('innerLabelLeftChange', this._afterInnerLabelLeftChange, this);
         this.after('innerLabelRightChange', this._afterInnerLabelRightChange, this);
@@ -141,13 +145,37 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
     },
 
     /**
-     * Fires when a pres space or enter key.
+     * Fires when space or enter key is pressed.
      *
      * @method _onButtonSwitchKey
      * @protected
      */
     _onButtonSwitchKey: function() {
         this._onButtonSwitchInteraction();
+    },
+
+    /**
+     * Adds value 'activated' when right arrow key is pressed.
+     *
+     * @method _onButtonSwitchRightKey
+     * @protected
+     */
+    _onButtonSwitchRightKey: function() {
+        if (!this.get('activated')) {
+            this._onButtonSwitchInteraction();
+        }
+    },
+
+    /**
+     * Removes value 'activated' when left arrow key is pressed.
+     *
+     * @method _onButtonSwitchLeftKey
+     * @protected
+     */
+    _onButtonSwitchLeftKey: function() {
+        if (this.get('activated')) {
+            this._onButtonSwitchInteraction();
+        }
     },
 
     /**

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -52,9 +52,11 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
      * @protected
      */
     renderUI: function() {
+        var buttonSwitch = this.get('contentBox');
         var content = this.get('content');
 
-        this.get('contentBox').append(content);
+        buttonSwitch.append(content);
+        buttonSwitch.setAttribute('role', 'switch');
 
         this._uiSetActivate(this.get('activated'));
         this._uiSetInnerLabelLeft(this.get('innerLabelLeft'));

--- a/src/aui-button/js/aui-button-switch.js
+++ b/src/aui-button/js/aui-button-switch.js
@@ -60,15 +60,15 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
         var content = this.get('content');
 
         buttonSwitch.append(content);
-        buttonSwitch.setAttribute('role', 'switch');
+        content.setAttribute('role', 'switch');
         this._uiSetActivate(this.get('activated'));
         this._uiSetInnerLabelLeft(this.get('innerLabelLeft'));
         this._uiSetInnerLabelRight(this.get('innerLabelRight'));
 
         if (this.get('activated')) {
-            buttonSwitch.setAttribute('aria-checked', 'true');
+            content.setAttribute('aria-checked', true);
         } else {
-            buttonSwitch.setAttribute('aria-checked', 'false');
+            content.setAttribute('aria-checked', false);
         }
     },
 
@@ -138,9 +138,9 @@ A.ButtonSwitch = A.Base.create('button-switch', A.Widget, [], {
         this.set('activated', !this.get('activated'));
 
         if (this.get('activated')) {
-            this.get('contentBox').setAttribute('aria-checked', 'true');
+            this.get('content').setAttribute('aria-checked', true);
         } else {
-            this.get('contentBox').setAttribute('aria-checked', 'false');
+            this.get('content').setAttribute('aria-checked', false);
         }
     },
 

--- a/src/aui-button/meta/aui-button.json
+++ b/src/aui-button/meta/aui-button.json
@@ -35,6 +35,7 @@
 
     "aui-button-switch": {
         "requires": [
+            "aui-aria",
             "aui-node-base",
             "base-build",
             "event-key",

--- a/src/aui-button/tests/unit/js/aui-button-switch-tests.js
+++ b/src/aui-button/tests/unit/js/aui-button-switch-tests.js
@@ -31,7 +31,7 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.areEqual(content.one('.button-switch-inner-label-right').getHTML(), 'right');
         },
 
-        'should active on click': function () {
+        'should activate on click': function () {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
@@ -77,7 +77,7 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.isFalse(content.one('.button-switch-inner-circle').hasClass('button-switch-right'));
         },
 
-        'should active on key enter interaction': function () {
+        'should activate on key enter interaction': function () {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
@@ -94,7 +94,7 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
         },
 
-        'should active on key space interaction': function () {
+        'should activate on key space interaction': function () {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
@@ -104,6 +104,23 @@ YUI.add('aui-button-switch-tests', function(Y) {
 
             this._buttonSwitch.get('content').simulate('keydown', {
                 keyCode: 32
+            });
+
+            Y.Assert.isTrue(buttonSwitch.get('activated'));
+            Y.Assert.isFalse(content.one('.button-switch-inner-label-left').hasClass('hide'));
+            Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
+        },
+
+        'should activate on key rightarrow interaction': function () {
+            var buttonSwitch = this._buttonSwitch,
+                content = buttonSwitch.get('content');
+
+            Y.Assert.isFalse(this._buttonSwitch.get('activated'));
+            Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
+            Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
+
+            this._buttonSwitch.get('content').simulate('keydown', {
+                keyCode: 39
             });
 
             Y.Assert.isTrue(buttonSwitch.get('activated'));

--- a/src/aui-button/tests/unit/js/aui-button-switch-tests.js
+++ b/src/aui-button/tests/unit/js/aui-button-switch-tests.js
@@ -40,7 +40,7 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
 
             content.simulate('click');
-            
+
             Y.Assert.isTrue(buttonSwitch.get('activated'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
@@ -57,7 +57,7 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
 
             content.simulate('click');
-            
+
             Y.Assert.isFalse(this._buttonSwitch.get('activated'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
@@ -128,6 +128,13 @@ YUI.add('aui-button-switch-tests', function(Y) {
             Y.Assert.isFalse(buttonSwitch.get('activated'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
+        },
+
+        'shouuld have role="switch" attribute in the button': function() {
+            var buttonSwitch = this._buttonSwitch,
+                content = buttonSwitch.get('content');
+
+            Y.Assert.isTrue(content.getAttribute('role') == 'switch');
         }
     }));
 

--- a/src/aui-button/tests/unit/js/aui-button-switch-tests.js
+++ b/src/aui-button/tests/unit/js/aui-button-switch-tests.js
@@ -81,11 +81,11 @@ YUI.add('aui-button-switch-tests', function(Y) {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
-            Y.Assert.isFalse(this._buttonSwitch.get('activated'));
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
 
-            this._buttonSwitch.get('content').simulate('keydown', {
+            buttonSwitch.get('content').simulate('keydown', {
                 keyCode: 13
             });
 
@@ -98,11 +98,11 @@ YUI.add('aui-button-switch-tests', function(Y) {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
-            Y.Assert.isFalse(this._buttonSwitch.get('activated'));
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
 
-            this._buttonSwitch.get('content').simulate('keydown', {
+            buttonSwitch.get('content').simulate('keydown', {
                 keyCode: 32
             });
 
@@ -115,17 +115,35 @@ YUI.add('aui-button-switch-tests', function(Y) {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
-            Y.Assert.isFalse(this._buttonSwitch.get('activated'));
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
 
-            this._buttonSwitch.get('content').simulate('keydown', {
+            buttonSwitch.get('content').simulate('keydown', {
                 keyCode: 39
             });
 
             Y.Assert.isTrue(buttonSwitch.get('activated'));
             Y.Assert.isFalse(content.one('.button-switch-inner-label-left').hasClass('hide'));
             Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
+        },
+
+        'should deactivate on key leftarrow interaction': function () {
+            var buttonSwitch = this._buttonSwitch,
+                content = buttonSwitch.get('content');
+
+            buttonSwitch.set('activated', true);
+            Y.Assert.isTrue(buttonSwitch.get('activated'));
+            Y.Assert.isFalse(content.one('.button-switch-inner-label-left').hasClass('hide'));
+            Y.Assert.isTrue(content.one('.button-switch-inner-label-right').hasClass('hide'));
+
+            buttonSwitch.get('content').simulate('keydown', {
+                keyCode: 37
+            });
+
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
+            Y.Assert.isTrue(content.one('.button-switch-inner-label-left').hasClass('hide'));
+            Y.Assert.isFalse(content.one('.button-switch-inner-label-right').hasClass('hide'));
         },
 
         'should toggle on interaction': function () {

--- a/src/aui-button/tests/unit/js/aui-button-switch-tests.js
+++ b/src/aui-button/tests/unit/js/aui-button-switch-tests.js
@@ -135,6 +135,22 @@ YUI.add('aui-button-switch-tests', function(Y) {
                 content = buttonSwitch.get('content');
 
             Y.Assert.isTrue(content.getAttribute('role') == 'switch');
+        },
+
+        'should toggle aria-checked attribute on interaction': function() {
+            var buttonSwitch = this._buttonSwitch,
+                content = buttonSwitch.get('content');
+
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
+            Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
+
+            content.simulate('click');
+            Y.Assert.isTrue(buttonSwitch.get('activated'));
+            Y.Assert.isTrue(content.getAttribute('aria-checked') == 'true');
+
+            content.simulate('click');
+            Y.Assert.isFalse(buttonSwitch.get('activated'));
+            Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
         }
     }));
 

--- a/src/aui-button/tests/unit/js/aui-button-switch-tests.js
+++ b/src/aui-button/tests/unit/js/aui-button-switch-tests.js
@@ -169,23 +169,27 @@ YUI.add('aui-button-switch-tests', function(Y) {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
-            Y.Assert.isTrue(content.getAttribute('role') == 'switch');
+            if (buttonSwitch.get('useARIA')) {
+                Y.Assert.isTrue(content.getAttribute('role') == 'switch');
+            }
         },
 
         'should toggle aria-checked attribute on interaction': function() {
             var buttonSwitch = this._buttonSwitch,
                 content = buttonSwitch.get('content');
 
-            Y.Assert.isFalse(buttonSwitch.get('activated'));
-            Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
+            if (buttonSwitch.get('useARIA')) {
+                Y.Assert.isFalse(buttonSwitch.get('activated'));
+                Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
 
-            content.simulate('click');
-            Y.Assert.isTrue(buttonSwitch.get('activated'));
-            Y.Assert.isTrue(content.getAttribute('aria-checked') == 'true');
+                content.simulate('click');
+                Y.Assert.isTrue(buttonSwitch.get('activated'));
+                Y.Assert.isTrue(content.getAttribute('aria-checked') == 'true');
 
-            content.simulate('click');
-            Y.Assert.isFalse(buttonSwitch.get('activated'));
-            Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
+                content.simulate('click');
+                Y.Assert.isFalse(buttonSwitch.get('activated'));
+                Y.Assert.isFalse(content.getAttribute('aria-checked') == 'true');
+            }
         }
     }));
 


### PR DESCRIPTION
A note about line 43: 

According to the YUI docs there are only a limited number of keys defined in this key map (console.log shows which keys are defined): 

Y.Node.DOM_EVENTS.key.eventDef.KEY_MAP 

Enter and Space are defined in this key map therefore their names can be used. Unless we define more keys in this map, keycodes must be used. 

e.g.,
Y.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowright= 39;
Y.Node.DOM_EVENTS.key.eventDef.KEY_MAP.arrowleft= 37;

I submitted a PR with the code above before, adding right and left keys to the map but you wanted it done differently. Part of the reason why I used the keycodes instead on line 43. 

