### PR TITLE
AUI-3114 Client request - Change default event description

### DIFF
--- a/src/aui-scheduler/js/aui-scheduler-base.js
+++ b/src/aui-scheduler/js/aui-scheduler-base.js
@@ -200,6 +200,17 @@ A.SchedulerEvents = A.Base.create('scheduler-events', A.ModelList, [], {
      */
     ATTRS: {
         /**
+         * Default text for event creation description.
+         *
+         * @attribute defaultDescriptionHint
+         * @default 'Dinner at Brian\'s'
+         * @type {String}
+         */
+        defaultDescriptionHint: {
+            value: 'Dinner at Brian\'s'
+        },
+
+        /**
          * The original list of items.
          *
          * @attribute originalItems

--- a/src/aui-scheduler/js/aui-scheduler-event-recorder.js
+++ b/src/aui-scheduler/js/aui-scheduler-event-recorder.js
@@ -14,6 +14,8 @@ var Lang = A.Lang,
 
     DateMath = A.DataType.DateMath,
 
+    defaultDescriptionHint = A.SchedulerEvents.ATTRS.defaultDescriptionHint.value,
+
     getCN = A.getClassName,
 
     CSS_FORM_CONTROL = getCN('form', 'control'),
@@ -140,7 +142,7 @@ var SchedulerEventRecorder = A.Component.create({
             setter: function(val) {
                 return A.merge({
                         'delete': 'Delete',
-                        'description-hint': 'e.g., Dinner at Brian\'s',
+                        'description-hint': defaultDescriptionHint,
                         cancel: 'Cancel',
                         description: 'Description',
                         edit: 'Edit',


### PR DESCRIPTION
2 of 2

Jon,

The client requested a way to change the default event description. 

I modified the Alloy files and I believe this could be a fix we can push and not disrupt any other users. User should just be able to pass in a value for defaultDescriptionHint during the component creation on the html to change it, otherwise, it defaults to "Dinner at Brian's"