### PR TITLE
AUI-3127 IFrame dialog cannot be closed with the escape key if an action on the dialog causes it to reload

### DIFF
--- a/src/aui-dialog-iframe-deprecated/HISTORY.md
+++ b/src/aui-dialog-iframe-deprecated/HISTORY.md
@@ -5,3 +5,4 @@
 ## @VERSION@
 
 * [AUI-3122](https://issues.liferay.com/browse/AUI-3122) iframe is created without title attribute
+* [AUI-3127](https://issues.liferay.com/browse/AUI-3127) IFrame dialog cannot be closed with the escape key if an action on the dialog causes it to reload

--- a/src/aui-dialog-iframe-deprecated/js/aui-dialog-iframe-deprecated.js
+++ b/src/aui-dialog-iframe-deprecated/js/aui-dialog-iframe-deprecated.js
@@ -340,22 +340,20 @@ var DialogIframePlugin = A.Component.create({
             var instance = this;
 
             if (instance.get(CLOSE_ON_ESCAPE)) {
-                if (!instance._eventCloseOnEscapeHandle) {
-                    try {
-                        var iframeWindow = instance.node.get(CONTENT_WINDOW);
+                try {
+                    var iframeWindow = instance.node.get(CONTENT_WINDOW);
 
-                        var iframeDoc = iframeWindow.get(DOCUMENT);
+                    var iframeDoc = iframeWindow.get(DOCUMENT);
 
-                        instance._eventCloseOnEscapeHandle = A.on(
-                            KEY,
-                            function() {
-                                instance._host.hide();
-                            }, [iframeDoc],
-                            'down:27'
-                        );
-                    }
-                    catch (exception) {}
+                    instance._eventCloseOnEscapeHandle = A.on(
+                        KEY,
+                        function() {
+                            instance._host.hide();
+                        }, [iframeDoc],
+                        'down:27'
+                    );
                 }
+                catch (exception) {}
             }
             else if (instance._eventCloseOnEscapeHandle) {
                 instance._eventCloseOnEscapeHandle.detach();

--- a/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
+++ b/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
@@ -45,6 +45,20 @@ YUI.add('aui-dialog-iframe-tests', function(Y) {
             this.wait(function() {
                 Y.Assert.isFalse(maskNode.inDoc());
             }, 100);
+        },
+
+        /**
+         * @tests AUI-3127
+         */
+        'test dialog-iframe-modal is closed after the escape key is pressed': function() {
+            this.wait(function() {
+                modal.iframe._eventCloseOnEscapeHandle.detach();
+                modal.iframe._defaultLoadIframeFn();
+
+                modal.iframe.node.get('contentWindow').get('document').simulate('keydown', {keyCode: 27});
+
+                Y.Assert.isFalse(modal.get('visible'), 'The modal should not be visible after the escape key is pressed');
+            }, 100);
         }
     }));
 

--- a/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
+++ b/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
@@ -2,24 +2,24 @@ YUI.add('aui-dialog-iframe-tests', function(Y) {
 
     var suite = new Y.Test.Suite('aui-dialog-iframe-deprecated');
 
-	var modal = new Y.Modal(
-		{
-			headerContent: '<h3>My Dialog</h3>',
-			width: 640,
-			centered: true,
-			height: 400,
-			zIndex: 1,
-			destroyOnHide: true
-		}
-	)
-	.plug(
-		Y.Plugin.DialogIframe,
-		{
-			uri: '../../../../demos/dialog-iframe-deprecated/assets/content.html',
-			iframeCssClass: 'dialog-iframe'
-		}
-	)
-	.render();
+    var modal = new Y.Modal(
+        {
+            headerContent: '<h3>My Dialog</h3>',
+            width: 640,
+            centered: true,
+            height: 400,
+            zIndex: 1,
+            destroyOnHide: true
+        }
+    )
+    .plug(
+        Y.Plugin.DialogIframe,
+        {
+            uri: '../../../../demos/dialog-iframe-deprecated/assets/content.html',
+            iframeCssClass: 'dialog-iframe'
+        }
+    )
+    .render();
 
     suite.add(new Y.Test.Case({
         name: 'DialogIframe',
@@ -28,15 +28,14 @@ YUI.add('aui-dialog-iframe-tests', function(Y) {
          * @tests AUI-1422
          */
         'test loading mask is destroyed when host is destroyed': function() {
-        	var maskCssClass = modal.bodyNode.loadingmask.overlayMask.get('cssClass'),
-        		maskNode = Y.one('.' + maskCssClass);
+            var maskCssClass = modal.bodyNode.loadingmask.overlayMask.get('cssClass'),
+                maskNode = Y.one('.' + maskCssClass);
 
-        	modal.hide();
+            modal.hide();
 
-        	this.wait(function() {
-        		Y.Assert.isFalse(maskNode.inDoc());
-        	}, 100);
-
+            this.wait(function() {
+                Y.Assert.isFalse(maskNode.inDoc());
+            }, 100);
         }
     }));
 

--- a/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
+++ b/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
@@ -35,10 +35,12 @@ YUI.add('aui-dialog-iframe-tests', function(Y) {
          * @tests AUI-1422
          */
         'test loading mask is destroyed when host is destroyed': function() {
-            var maskCssClass = modal.bodyNode.loadingmask.overlayMask.get('cssClass'),
-                maskNode = Y.one('.' + maskCssClass);
+            this.wait(function() {
+                var maskCssClass = modal.bodyNode.loadingmask.overlayMask.get('cssClass'),
+                    maskNode = Y.one('.' + maskCssClass);
 
-            modal.hide();
+                modal.hide();
+            }, 100);
 
             this.wait(function() {
                 Y.Assert.isFalse(maskNode.inDoc());

--- a/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
+++ b/src/aui-dialog-iframe-deprecated/tests/unit/js/tests.js
@@ -1,28 +1,35 @@
 YUI.add('aui-dialog-iframe-tests', function(Y) {
 
-    var suite = new Y.Test.Suite('aui-dialog-iframe-deprecated');
-
-    var modal = new Y.Modal(
-        {
-            headerContent: '<h3>My Dialog</h3>',
-            width: 640,
-            centered: true,
-            height: 400,
-            zIndex: 1,
-            destroyOnHide: true
-        }
-    )
-    .plug(
-        Y.Plugin.DialogIframe,
-        {
-            uri: '../../../../demos/dialog-iframe-deprecated/assets/content.html',
-            iframeCssClass: 'dialog-iframe'
-        }
-    )
-    .render();
+    var suite = new Y.Test.Suite('aui-dialog-iframe-deprecated'),
+        modal;
 
     suite.add(new Y.Test.Case({
         name: 'DialogIframe',
+
+        setUp: function() {
+            if (modal) {
+                modal.destroy();
+            }
+
+            modal = new Y.Modal(
+                {
+                    headerContent: '<h3>My Dialog</h3>',
+                    width: 640,
+                    centered: true,
+                    height: 400,
+                    zIndex: 1,
+                    destroyOnHide: true
+                }
+            )
+            .plug(
+                Y.Plugin.DialogIframe,
+                {
+                    uri: '../../../../demos/dialog-iframe-deprecated/assets/content.html',
+                    iframeCssClass: 'dialog-iframe'
+                }
+            )
+            .render();
+        },
 
         /**
          * @tests AUI-1422


### PR DESCRIPTION
Hey @jonmak08,

This is an update for https://issues.liferay.com/browse/AUI-3127.

Please let me know if you have any questions.

Thanks!