### PR TITLE
AUI-3134 Fixes memory leak with multiple instances of A.DD.Drop by not using it

### DIFF
--- a/src/aui-layout/assets/aui-layout-builder-resize-col-core.css
+++ b/src/aui-layout/assets/aui-layout-builder-resize-col-core.css
@@ -1,4 +1,4 @@
-.layout-builder-resize-col-breakpoint {
+.layout-builder-resize-dragging .layout-builder-resize-col-breakpoint {
     display: block;
 }
 
@@ -7,7 +7,7 @@
     display: none;
     position: absolute;
     top: 0;
-    width: 0;
+    width: 1px;
     z-index: 2;
 }
 

--- a/src/aui-layout/js/aui-layout-builder-resize-col.js
+++ b/src/aui-layout/js/aui-layout-builder-resize-col.js
@@ -285,7 +285,6 @@ A.LayoutBuilderResizeCol.prototype = {
             this.after('layout-row:colsChange', this._afterResizeColLayoutColsChange),
             this._delegateDrag.after('drag:align', A.bind(this._afterDragAlign, this)),
             this._delegateDrag.after('drag:end', A.bind(this._afterDragEnd, this)),
-            this._delegateDrag.after('drag:enter', A.bind(this._afterDragEnter, this)),
             this._delegateDrag.after('drag:mouseDown', A.bind(this._afterDragMouseDown, this)),
             this._delegateDrag.after('drag:mouseup', A.bind(this._afterDragMouseup, this)),
             this._delegateDrag.after('drag:start', A.bind(this._afterDragStart, this)),

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -149,7 +149,7 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 visible = [];
 
             nodes.each(function(node) {
-                if (node.getStyle('display') !== 'none') {
+                if (node.get('offsetParent')) {
                     visible.push(node);
                 }
             });

--- a/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
+++ b/src/aui-layout/tests/unit/js/aui-layout-builder-resize-col-tests.js
@@ -313,9 +313,6 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
             dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
             dragHandle.simulate('mousedown');
 
-            breakpoints = this._getVisibleRowNodes(row, '.' + CSS_RESIZE_COL_BREAKPOINT);
-            Y.Assert.areEqual(9, breakpoints.length);
-
             Y.Array.each(breakpoints, function(breakpoint, position) {
                 Y.Assert.areEqual(position, breakpoint.getData('layout-position'));
             });
@@ -377,23 +374,8 @@ YUI.add('aui-layout-builder-resize-col-tests', function(Y) {
                 row = this._layoutBuilder.get('layout').get('rows')[1];
 
             dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
-
-            this._simulateDrag(this, dragHandle, [1000, 10], function() {
-                Y.Assert.areEqual(6, row.get('cols')[0].get('size'));
-                Y.Assert.areEqual(6, row.get('cols')[1].get('size'));
-            });
-        },
-
-        'should not resize column if handle move': function() {
-            var dragHandle,
-                dragNode,
-                row = this._layoutBuilder.get('layout').get('rows')[1];
-
-            dragHandle = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE_HANDLE).item(2);
-
-            this._simulateDrag(this, dragHandle, undefined, function() {
-                dragNode = row.get('node').all('.' + CSS_RESIZE_COL_DRAGGABLE).item(2);
-                Y.Assert.areEqual(6, dragNode.getData('layout-position'));
+            // Simulates a 'drag' that doesn't move at all.
+            this._simulateDrag(this, dragHandle, dragHandle.getXY(), function() {
                 Y.Assert.areEqual(6, row.get('cols')[0].get('size'));
                 Y.Assert.areEqual(6, row.get('cols')[1].get('size'));
             });


### PR DESCRIPTION
Hey Jon,

This makes some performance issues with Form Builder less of a problem. The Forms team is working on adding Drag and Drop functionality to the Form Builder in portal. After each drag interaction, they ask the Form Builder to repaint it self. When it does that, I noticed memory allocation going up quite a lot, making the component slower. I think I managed to narrow down the issue to A.DD.Drop instances not getting cleared by the garbage collector. I couldn't fix it in a more generic way, so I simply removed usages of DD.Drop and implemented the functionality they needed in a simpler way. Memory usage is much better now. Let me know if you have any questions.

Thanks