### PR TITLE
AUI-3142 - Focus on datepicker

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker-delegate.js
+++ b/src/aui-datepicker/js/aui-datepicker-delegate.js
@@ -310,8 +310,6 @@ DatePickerDelegate.prototype = {
         instance.useInputNodeOnce(event.currentTarget);
 
         instance._userInteractionInProgress = true;
-
-        instance._focusActiveCalendar();
     },
 
     /**

--- a/src/aui-datepicker/js/aui-datepicker.js
+++ b/src/aui-datepicker/js/aui-datepicker.js
@@ -300,7 +300,7 @@ A.mix(DatePickerBase.prototype, {
 
         newDates = A.Array.dedupe(newDates);
 
-        if (newDates.length !== prevDates.length || newSelection.length < prevDates.length) {
+        if (newSelection.length > 0 && (newDates.length !== prevDates.length || newSelection.length < prevDates.length)) {
             instance.fire('selectionChange', {
                 newSelection: newSelection
             });


### PR DESCRIPTION
Hi @jonmak08 ,

Can you review this PR, please? You can find further information in [AUI-3142](https://issues.liferay.com/browse/AUI-3142).

[This commit](https://github.com/jonmak08/alloy-ui/commit/42ee202344f124d11f581d3e57d3b4114b81badc) tries to solve 'Issue 1' explained on JIRA. As far as I understand that line was added to allow keyboard accesibility but after remove it you are still able to open the calendar and move through it.

[This commit](https://github.com/jonmak08/alloy-ui/commit/30de83fb235c87b2907ea9e253f9233a5d5e8fb2) tries to solve 'Issue 2' explained on JIRA. We only shoud fire that event when a new date has been selected on Calendar, no when we remove the date without selecting a new one.

Don't hesitate to ask me any question.

Thanks in advance,