### PR TITLE
[TECHNICAL SUPPORT] AUI-3152 Reselecting current date in the datepicker, after deleting it from the input field, will result into a blank date

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker.js
+++ b/src/aui-datepicker/js/aui-datepicker.js
@@ -292,13 +292,23 @@ A.mix(DatePickerBase.prototype, {
      */
     _afterCalendarSelectionChange: function(event) {
         var instance = this,
+            activeInput = instance.get('activeInput'),
             newDates,
             newSelection = event.newSelection,
-            prevDates = instance.getSelectedDates() || [];
+            prevDates = instance.getSelectedDates() || [],
+            valueFormatter = instance.get('valueFormatter');
 
         newDates = newSelection.concat(prevDates);
 
         newDates = A.Array.dedupe(newDates);
+
+        if (newSelection.length === 0) {
+          valueFormatter.call(instance, prevDates);
+
+          if (activeInput) {
+              activeInput.setData('datepickerSelection', prevDates);
+          }
+        }
 
         if (newSelection.length && (newDates.length !== prevDates.length || newSelection.length < prevDates.length)) {
             instance.fire('selectionChange', {


### PR DESCRIPTION
Hey @jonmak08 ,

Please find related [LPP-30987](https://issues.liferay.com/browse/LPP-30987),
and releated [AUI-3152](https://issues.liferay.com/browse/AUI-3152)

When the user clears the current(not just today's) date from the input field and try to reselect it from the datepicker, the input field won`t be updated.

Im not sure about the real life use case of this issue, however I created a fix that would solve this problem. I'd like to ask you to decide if this behavior is intended and if not please review my PR with the proposed solution.

Thanks,