### PR TITLE
AUI-3174 Improve consistency by focusing to the center of viewport.

### DIFF
--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -694,7 +694,9 @@ var FormValidator = A.Component.create({
 
                 field.focus();
 
-                field.scrollIntoView();
+                field.scrollIntoView(false);
+
+                window.scrollBy(0,field.getDOM().scrollHeight);
             }
         },
 


### PR DESCRIPTION
Continuation of:

https://github.com/jonmak08/alloy-ui/pull/442
https://github.com/jonmak08/alloy-ui/commit/76f96c95881fb5757df93a5e0ecbdde20a6d428d#diff-f7aeae248c7d4fba1736b44860825c8d
https://github.com/jonmak08/alloy-ui/commit/0030a40438f9714806494aae7fb0487d36f9433a#diff-f7aeae248c7d4fba1736b44860825c8d

scrollIntoView, by default, uses "start" for Block property. By using "center" instead, we can minimize the inconsistency of the field potentially being blocked in scenarios such as : https://issues.liferay.com/browse/LPS-100614

by ensuring we focus to the center of the viewport.

Sincerely,
Brian Kim