### PR TITLE
AUI-3184 Last row in Calendar portlet blue border is not visible

### DIFF
--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -172,7 +172,7 @@
 }
 
 .scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
-    border-bottom-width: 1px;
+    border-bottom-width: 2px;
 }
 
 .scheduler-view-table-data-col-title-today {


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3184

This is a unique fix for 7.0 because even with https://issues.liferay.com/browse/AUI-3178 the set width is still not thick enough for this version. I've increased the width by 1px.