### PR TITLE
AUI-3182 In Calendar's monthly view, when today's date is the first day of the week, the blue border is cut out

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-3182](https://issues.liferay.com/browse/AUI-3182) In Calendar's monthly view, when today's date is the first day of the week, the blue border is cut out
 * [AUI-3148](https://issues.liferay.com/browse/AUI-3148) In Calendar's monthly view, when today's date is the last week of the month, the blue border is cut out
 * [AUI-3170](https://issues.liferay.com/browse/AUI-3170) Event icons missing on scheduler component
 * [AUI-3139](https://issues.liferay.com/browse/AUI-3139) Calendar - Vertical lines of the Main Scheduler table are not lining up with the All Day Event Scheduler table

--- a/src/aui-scheduler/assets/aui-scheduler-view-month-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-month-core.css
@@ -7,10 +7,6 @@
     min-height: 100px;
 }
 
-.scheduler-view-month .scheduler-view-table-colgrid-first {
-    border-left: 0 none;
-}
-
 .scheduler-view-month-table-data-col-nomonth {
     color: #ccc;
     font-size: 14px;

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,6 +171,10 @@
     border-bottom-width: 0;
 }
 
+.scheduler-view-table-grid:first-child .scheduler-view-table-colgrid-today {
+    border-left: 1px solid #009be6;
+}
+
 .scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
     border-bottom-width: 1px;
 }

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,10 +171,6 @@
     border-bottom-width: 0;
 }
 
-.scheduler-view-table-grid:first-child .scheduler-view-table-colgrid-today {
-    border-left: 1px solid #009be6;
-}
-
 .scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
     border-bottom-width: 1px;
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3182

Backporting the fix to 3.0.x because the issue is still reproducible in this version. 