### PR TITLE
 AUI-3174 Align to bottom of scrollable ancestor and scroll down by scrollHeight.

### DIFF
--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -694,7 +694,9 @@ var FormValidator = A.Component.create({
 
                 field.focus();
 
-                field.scrollIntoView();
+                field.scrollIntoView(false);
+
+                window.scrollBy(0,field.getDOM().scrollHeight);
             }
         },
 


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3174
https://issues.liferay.com/browse/LPS-100614
First, we set scrollIntoView to false so that the bottom of the element will be aligned to the bottom of the visible area of the scrollable ancestor.
![ScrollIntoViewFalse](https://user-images.githubusercontent.com/35237986/67501986-0d1c3800-f63a-11e9-8b6c-dd0d300e6320.png)

Then we fetch the scrollHeight of the field and scroll down by that amount.
![AfterScrollByScrollHeight](https://user-images.githubusercontent.com/35237986/67502013-14dbdc80-f63a-11e9-8f4c-e733e1306843.png)