### PR TITLE
AUI-3186 In Calendar portlet, when today's date is the last week of the year using monthly view, the blue border is cut out.

### DIFF
--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -959,6 +959,29 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Gets the number of weeks in given calendar year.
+     *
+     * @method getWeeksInYear
+     * @param {Number} year The calendar year for which to retrieve number of
+     *      weeks from.
+     * @param {Number} startOfWeek The index for the first day of the week, 0 =
+     *     Sun, 1 = Mon ... 6 = Sat (defaults to 0)
+     * @return {Number} The number of weeks for the given year
+     */
+    getWeeksInYear: function(year, startOfWeek) {
+        var date = this.getDate(year, 11, 31);
+        var weekNumber = this.getWeekNumber(date, startOfWeek, this.WEEK_ONE_JAN_DATE);
+
+        if (weekNumber === 1) {
+            date = this.getDate(year, 11, 24);
+
+            weekNumber = this.getWeekNumber(date, startOfWeek, this.WEEK_ONE_JAN_DATE);
+        }
+
+        return weekNumber;
+    },
+
+    /**
      * Converts a date to US time format.
      *
      * @method toUsTimeString

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -820,6 +820,13 @@ var SchedulerTableView = A.Component.create({
 
                 var rowIndex = DateMath.getWeekNumber(todayDate, firstDayOfWeek) - DateMath.getWeekNumber(
                     interval.startDate, firstDayOfWeek);
+
+                if (rowIndex < 0) {
+                    var weeksInYear = DateMath.getWeeksInYear(firstWeekDay.getFullYear(), firstDayOfWeek);
+
+                    rowIndex += weeksInYear;
+                }
+
                 var colIndex = (todayDate.getDay() - firstWeekDay.getDay() + WEEK_LENGTH) % WEEK_LENGTH;
 
                 var celIndex = instance._getCellIndex([colIndex, rowIndex]);


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3186

**Issue:**
The last week of the calendar year is not calculated correctly due to the return of a negative `rowIndex`. 

**Solution:**
When there is a negative `rowIndex`, we would calculate the number of weeks in the given year and find the sum between the `rowIndex` (week in month) and the number of weeks in the year. This returns the appropriate `rowIndex`.