### PR TITLE
AUI-3194 Fall back to field.ancestor() to avoid null object return

### DIFF
--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -670,9 +670,11 @@ var FormValidator = A.Component.create({
             var instance = this,
                 fieldContainer = instance.get('fieldContainer');
 
-            if (fieldContainer) {
+            if (fieldContainer && field.ancestor(fieldContainer)) {
                 return field.ancestor(fieldContainer);
-            }
+            } else {
+				return field.ancestor();
+			}
         },
 
         /**


### PR DESCRIPTION
Hi @jonmak08 

could you please check my fix and merge into master?

Thanks, Roland

https://github.com/liferay/alloy-ui/issues/166
https://issues.liferay.com/browse/AUI-3194
